### PR TITLE
CO-11323 : Incorporating ECS changes for vault docker image creation

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -3,6 +3,14 @@ FROM alpine:3.10
 # This is the release of Vault to pull in.
 ARG VAULT_VERSION=1.4.1
 
+# Install dependencies
+RUN \
+  apk add --update \
+  # Install jq, curl and aws cli (to get access to secret manager)
+  jq curl py2-pip
+  # Install awscli for secret manager
+RUN pip install --upgrade pip awscli
+
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.
 RUN addgroup vault && \
@@ -53,6 +61,7 @@ RUN set -eux; \
 RUN mkdir -p /vault/logs && \
     mkdir -p /vault/file && \
     mkdir -p /vault/config && \
+    mkdir -p /vault/ssl && \
     chown -R vault:vault /vault
 
 # Expose the logs directory as a volume since there's potentially long-running
@@ -67,6 +76,10 @@ VOLUME /vault/file
 # Vault.
 EXPOSE 8200
 
+# Interfaces for both cluster and listerner IP's
+ENV VAULT_REDIRECT_INTERFACE eth0
+ENV VAULT_CLUSTER_INTERFACE eth0
+
 # The entry point script uses dumb-init as the top-level process to reap any
 # zombie processes created by Vault sub-processes.
 #
@@ -77,4 +90,4 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 # By default you'll get a single-node development server that stores everything
 # in RAM and bootstraps itself. Don't use this configuration for production.
-CMD ["server", "-dev"]
+CMD ["server"]

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -9,6 +9,43 @@ set -e
 # Prevent core dumps
 ulimit -c 0
 
+echo 'Setting up environment variable'
+# Get the secrets from AWS secret manager only for non-development environments
+if [ "$VAULT_ENV" != "development" ]; then
+  ####################### FETCH THE SECRETS FROM AWS SECRET MANAGER AND EXPORT AS ENV VARIABLE ###########################
+  [ -z "$CLOUD_REGION" ] && export CLOUD_REGION=$(wget http://169.254.169.254/latest/meta-data/placement/availability-zone/ -q -O - | sed -E "s/([a-z0-9-]+)[a-z]+/\1/")
+  [ -z "$AWS_SM_REGION" ] && export AWS_SM_REGION=${CLOUD_REGION}
+
+  if [ -z "${AWSSM_NAME}" ]; then
+    echo "Critical error, AWSSM_NAME not set! exiting"
+    exit 1
+  fi
+
+  secrets=$(aws secretsmanager get-secret-value --secret-id ${AWSSM_NAME} --region ${AWS_SM_REGION} | jq .SecretString -r )
+  keys=$(echo $secrets | jq '. | keys[] ')
+  echo "After SM fetch..."
+ 
+  # Loop through the keys and export them
+  for key in $keys
+  do
+    key_new=$(echo $key | sed 's/"//g' )
+    export $key_new=$(echo $secrets | jq ".[$key]" | sed 's/"//g')
+  done
+  ########################## FETCH THE SECRETS FROM AWS SECRET MANAGER AND EXPORT AS ENV VARIABLE ###########################
+fi
+
+if [ -n "$APP_CERT_NAME" ]; then
+  secrets=$(aws secretsmanager get-secret-value --secret-id ${APP_CERT_NAME} --region ${AWS_SM_REGION} | jq .SecretString -r )
+  keys=$(echo $secrets | jq '. | keys[] ')
+  # Loop through the keys and export them
+  for key in $keys
+  do
+    key_new=$(echo $key | sed 's/"//g' )
+    key_value=$(echo -e $secrets | jq ".[$key]" | sed 's/"//g')
+    echo -e ${key_value} >> /vault/ssl/${key_new}.pem
+  done
+fi
+
 # Allow setting VAULT_REDIRECT_ADDR and VAULT_CLUSTER_ADDR using an interface
 # name instead of an IP address. The interface name is specified using
 # VAULT_REDIRECT_INTERFACE and VAULT_CLUSTER_INTERFACE environment variables. If
@@ -24,7 +61,7 @@ get_addr () {
 }
 
 if [ -n "$VAULT_REDIRECT_INTERFACE" ]; then
-    export VAULT_REDIRECT_ADDR=$(get_addr $VAULT_REDIRECT_INTERFACE ${VAULT_REDIRECT_ADDR:-"http://0.0.0.0:8200"})
+    export VAULT_REDIRECT_ADDR=$(get_addr $VAULT_REDIRECT_INTERFACE ${VAULT_REDIRECT_ADDR:-"https://0.0.0.0:8200"})
     echo "Using $VAULT_REDIRECT_INTERFACE for VAULT_REDIRECT_ADDR: $VAULT_REDIRECT_ADDR"
 fi
 if [ -n "$VAULT_CLUSTER_INTERFACE" ]; then
@@ -32,15 +69,44 @@ if [ -n "$VAULT_CLUSTER_INTERFACE" ]; then
     echo "Using $VAULT_CLUSTER_INTERFACE for VAULT_CLUSTER_ADDR: $VAULT_CLUSTER_ADDR"
 fi
 
+export STATSD_ADDRESS=$(get_addr $VAULT_REDIRECT_INTERFACE ${STATSD_ADDRESS:-"0.0.0.0:8125"})
+echo "Using $VAULT_REDIRECT_INTERFACE for STATSD_ADDRESS: $STATSD_ADDRESS"
+
 # VAULT_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use
 # VAULT_LOCAL_CONFIG below.
 VAULT_CONFIG_DIR=/vault/config
 
+VAULT_LOCAL_CONFIG=$(cat <<EOF
+listener "tcp" {
+  address         = "0.0.0.0:8200"
+  cluster_address = "0.0.0.0:8201"
+  tls_cert_file   = "/vault/ssl/app_ssl_certificate.pem"
+  tls_key_file    = "/vault/ssl/app_ssl_certificate_key.pem"
+}
+
+storage "mysql" {
+    address = "${DATABASE_HOSTNAME}"
+    username = "${DATABASE_USERNAME}"
+    password = "${DATABASE_PASSWORD}"
+    database = "${DATABASE_NAME}"
+    ha_enabled = "${VAULT_HA_ENABLED}"
+    lock_table = "${VAULT_HA_LOCK_TABLE}"
+}
+
+telemetry {
+    statsd_address = "${STATSD_ADDRESS}"
+}
+
+cluster_addr  = "${VAULT_CLUSTER_ADDR}"
+api_addr      = "${VAULT_REDIRECT_ADDR}"
+EOF
+)
+
 # You can also set the VAULT_LOCAL_CONFIG environment variable to pass some
 # Vault configuration JSON without having to bind any volumes.
 if [ -n "$VAULT_LOCAL_CONFIG" ]; then
-    echo "$VAULT_LOCAL_CONFIG" > "$VAULT_CONFIG_DIR/local.json"
+    echo "$VAULT_LOCAL_CONFIG" > "$VAULT_CONFIG_DIR/default.hcl"
 fi
 
 # If the user is trying to run Vault directly with some arguments, then
@@ -54,8 +120,6 @@ if [ "$1" = 'server' ]; then
     shift
     set -- vault server \
         -config="$VAULT_CONFIG_DIR" \
-        -dev-root-token-id="$VAULT_DEV_ROOT_TOKEN_ID" \
-        -dev-listen-address="${VAULT_DEV_LISTEN_ADDRESS:-"0.0.0.0:8200"}" \
         "$@"
 elif [ "$1" = 'version' ]; then
     # This needs a special case because there's no help output.


### PR DESCRIPTION
## JIRA

* [JIRA ticket](https://coupadev.atlassian.net/browse/CO-11323)

## Summary of issue

Open source vault docker image doesn't have support for AWS secret manager.

## Summary of change

Things which we have modified in open source image :
- Added custom SSL certs
- Added Secret Manager support to fetch the secrets
- Removing dev mode and running vault in prod mode
