### PR TITLE
CE-18929 : Updating docker binary version to 1.9.9

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.16
 
 # This is the release of Vault to pull in.
-ARG VAULT_VERSION=1.9.8
+ARG VAULT_VERSION=1.9.9
 
 # Install dependencies
 RUN \


### PR DESCRIPTION
##JIRA

[JIRA](https://coupadev.atlassian.net/browse/CE-18929)

## Summary

- Updating vault binary version to update the [go](https://github.com/hashicorp/vault/tree/v1.9.9) library version