### PR TITLE
CE-19594 added vault 1.12.2

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.16
 
 # This is the release of Vault to pull in.
-ARG VAULT_VERSION=1.9.9
+ARG VAULT_VERSION=1.12.2
 
 # Install dependencies
 RUN \

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 # This is the release of Vault to pull in.
 ARG VAULT_VERSION=1.12.2

--- a/cd.sh
+++ b/cd.sh
@@ -42,7 +42,7 @@ function vaultDockerfileLint
 function vaultImageBuild
 {
   infoLog "Building Vault Image with tag ${IMAGE_TAG}"
-  /usr/bin/docker build -t ${IMAGE_TAG} $(dirname ${DOCKERFILE_PATH})
+  /usr/bin/docker build -t ${IMAGE_TAG} $(dirname ${DOCKERFILE_PATH}) --network host
 }
 
 function ecrDockerLogin


### PR DESCRIPTION
##JIRA

[JIRA](https://coupadev.atlassian.net/browse/CE-19594)

## Summary

- Updating vault binary version to update the [go](https://github.com/hashicorp/vault/releases/tag/v1.12.2) library version

