### PR TITLE
CENG-1048 Update alpine image to 3.17.2 and vault 1.12.3

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.17.2
 
 # This is the release of Vault to pull in.
 ARG VAULT_VERSION=1.12.2

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.17.2
 
 # This is the release of Vault to pull in.
-ARG VAULT_VERSION=1.12.2
+ARG VAULT_VERSION=1.12.3
 
 # Install dependencies
 RUN \


### PR DESCRIPTION
##JIRA

[CENG-1048](https://coupadev.atlassian.net/browse/CENG-1048)

[CENG-1048]: https://coupadev.atlassian.net/browse/CENG-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

##Summary
Updated alpine image to 3.17.2  and vault to 1.12.3 from 1.12.2 to resolve vulnerabilities CVE-2022-3996 and CVE-2022-43551