### PR TITLE
CENG-2027: Alpine->3.18.0 & Vault -> 1.12.6

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.17.2
+FROM alpine:3.18.0
 
 # This is the release of Vault to pull in.
-ARG VAULT_VERSION=1.12.3
+ARG VAULT_VERSION=1.12.6
 
 # Install dependencies
 RUN \
@@ -18,7 +18,7 @@ RUN addgroup vault && \
 
 # Set up certificates, our base tools, and Vault.
 RUN set -eux; \
-    apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init tzdata && \
+    apk add --no-cache ca-certificates gnupg openssl libcap su-exec dumb-init tzdata gnupg-keyboxd && \
     apkArch="$(apk --print-arch)"; \
     case "$apkArch" in \
         armhf) ARCH='arm' ;; \
@@ -52,7 +52,7 @@ RUN set -eux; \
     rm -rf /tmp/build && \
     gpgconf --kill dirmngr && \
     gpgconf --kill gpg-agent && \
-    apk del gnupg openssl && \
+    apk del gnupg openssl gnupg-keyboxd && \
     rm -rf /root/.gnupg
 
 # /vault/logs is made available to use as a location to store audit logs, if

--- a/cd.sh
+++ b/cd.sh
@@ -101,7 +101,7 @@ function upgradeVaultCluster
   region=$1
   cluster=$2
   infoLog "Upgrading AWS Coupadev Vault Cluster ${cluster} from region ${region} with Vault Image tag ${VAULT_VERSION}"
-  cd /opt/coupa-flash/5.0 && bundle exec rake services:ecs:update_docker_image["${cluster}","${VAULT_VERSION}"]
+  cd /opt/coupa-flash/6.0 && bundle exec rake services:ecs:update_docker_image["${cluster}","${VAULT_VERSION}"]
 }
 
 CD_OPERATION="$1"


### PR DESCRIPTION
For [Jira Ticket Link](https://coupadev.atlassian.net/browse/CENG-2077)
Latest Alpine image used 3.18.0 and Vault upgraded to 1.12.6.