### PR TITLE
DEVOPS-364 updated vault server to 1.14.4 and alpine to 3.18.4

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.4
 
 # This is the release of Vault to pull in.
-ARG VAULT_VERSION=1.13.8
+ARG VAULT_VERSION=1.14.4
 
 # Install dependencies
 RUN \

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.18.2
+FROM alpine:3.18.4
 
 # This is the release of Vault to pull in.
-ARG VAULT_VERSION=1.12.10
+ARG VAULT_VERSION=1.13.8
 
 # Install dependencies
 RUN \


### PR DESCRIPTION
Updating vault server image to 1.14.4 and alpine image to 3.18.4 for vulnerability https://github.com/coupa-ops/workflows/actions/runs/6464950531/job/17550382594

Testing notes
[DEVOPS-364](https://coupadev.atlassian.net/browse/DEVOPS-364)

[DEVOPS-364]: https://coupadev.atlassian.net/browse/DEVOPS-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ